### PR TITLE
docs: Providers vs imports

### DIFF
--- a/content/docs/providers-vs-imports.md
+++ b/content/docs/providers-vs-imports.md
@@ -1,3 +1,33 @@
 Don't list a service in `providers` array of a module unless the module really *provides* the service.
 If your `ServiceA` depends on a `ServiceB` from different module `ModuleB`, add `ServiceB` to `ModuleB`s `exports` array, 
 then add `ModuleB` to `imports` array in your module.
+```ts
+@Module({
+  providers: [ServiceB],
+  exports: [
+    ServiceB // <-- export the "ServiceB" provider by adding it to the module's exports array
+  ], 
+})
+export class ModuleB {}
+```
+```ts
+@Module({
+  imports: [
+    ModuleB // <-- modules that wish to inject the "ServiceB" will need to import the "ModuleB" in their imports array
+  ],  
+  providers: [ServiceA],
+})
+export class ModuleA {}
+```
+```ts
+import { ServiceB } from '../module-b.module'
+
+@Injectable()
+export class ServiceA {
+  constructor(private readonly serviceB: ServiceB) {}
+  
+  // async foo() {
+  //   this.serviceB.bar();
+  // }
+}
+```

--- a/content/docs/providers-vs-imports.md
+++ b/content/docs/providers-vs-imports.md
@@ -1,0 +1,3 @@
+Don't list a service in `providers` array of a module unless the module really *provides* the service.
+If your `ServiceA` depends on a `ServiceB` from different module `ModuleB`, add `ServiceB` to `ModuleB`s `exports` array, 
+then add `ModuleB` to `imports` array in your module.

--- a/content/docs/providers-vs-imports.md
+++ b/content/docs/providers-vs-imports.md
@@ -20,7 +20,7 @@ export class ModuleB {}
 export class ModuleA {}
 ```
 ```ts
-import { ServiceB } from '../module-b.module'
+import { ServiceB } from '../module-b/service-b.service'
 
 @Injectable()
 export class ServiceA {


### PR DESCRIPTION
Work in progress, opening this for discussion.

I've seen this so many times - users add a service into `providers` when they get the _service not found_ error. Obviously, this causes other unexpected issues.